### PR TITLE
Circle hover solution

### DIFF
--- a/030_hover_effect_on_circles/blue_circle.tscn
+++ b/030_hover_effect_on_circles/blue_circle.tscn
@@ -9,7 +9,7 @@ script = ExtResource("1_uyyar")
 [node name="Sprite2D" type="Sprite2D" parent="."]
 texture = ExtResource("1_3hxak")
 
-[node name="Area2D" type="Area2D" parent="."]
+[node name="BlueArea2D" type="Area2D" parent="."]
 
-[node name="CollisionPolygon2D" type="CollisionPolygon2D" parent="Area2D"]
+[node name="CollisionPolygon2D" type="CollisionPolygon2D" parent="BlueArea2D"]
 polygon = PackedVector2Array(-8, -27, -1, -27, 8, -19, 18, 6, 17, 18, 11, 22, 3, 22, -6, 15, -14, 1, -15, -14, -12, -24)

--- a/030_hover_effect_on_circles/circle.gd
+++ b/030_hover_effect_on_circles/circle.gd
@@ -1,14 +1,10 @@
 extends Node2D
+class_name Circle
 
 
-func _ready() -> void:
-	$Area2D.connect('mouse_entered', mouse_entered)
-	$Area2D.connect('mouse_exited', mouse_exited)
-
-
-func mouse_entered():
+func scale_up():
 	$Sprite2D.scale = Vector2.ONE * 1.15
 
 
-func mouse_exited():
+func scale_down():
 	$Sprite2D.scale = Vector2.ONE

--- a/030_hover_effect_on_circles/main.gd
+++ b/030_hover_effect_on_circles/main.gd
@@ -1,0 +1,46 @@
+extends Node2D
+
+var direct_space_state: PhysicsDirectSpaceState2D 
+var currently_hovered_circle: Circle:
+	set(value):
+		if currently_hovered_circle == value: return
+		print(value)
+		
+		if currently_hovered_circle != null: 
+			currently_hovered_circle.scale_down()
+		
+		if value != null:
+			value.scale_up()
+		
+		currently_hovered_circle = value
+
+func _ready() -> void:
+	direct_space_state = get_tree().root.world_2d.direct_space_state
+
+
+func _input(event: InputEvent) -> void:
+	if event is InputEventMouseMotion:
+		var params := PhysicsPointQueryParameters2D.new()
+		params.collide_with_areas = true
+		#params.collision_mask = you can optionally provide a layermask for the areas if you wish
+		
+		params.position = get_global_mouse_position()
+		
+		var result: Array[Dictionary] = direct_space_state.intersect_point(params)
+		if !result.is_empty():
+			
+			result.sort_custom(sort_based_on_tree_order)
+			
+			#print(result)
+			var circle: Circle = result[0].collider.owner as Circle
+			#print(circle.name)
+			currently_hovered_circle = circle
+			#print("_____________________________________")
+		else:
+			currently_hovered_circle = null #if nothing is hovered, set to null
+
+func sort_based_on_tree_order(dict_a, dict_b):
+	var circle_a := dict_a.collider.owner as Circle
+	var circle_b := dict_b.collider.owner as Circle
+	
+	return circle_a.is_greater_than(circle_b)

--- a/030_hover_effect_on_circles/main.tscn
+++ b/030_hover_effect_on_circles/main.tscn
@@ -1,10 +1,12 @@
-[gd_scene load_steps=4 format=3 uid="uid://bf33xqoer8xeu"]
+[gd_scene load_steps=5 format=3 uid="uid://bf33xqoer8xeu"]
 
+[ext_resource type="Script" path="res://main.gd" id="1_g77aw"]
 [ext_resource type="PackedScene" uid="uid://bv0jjt4cjeomk" path="res://red_circle.tscn" id="1_ncan8"]
 [ext_resource type="PackedScene" uid="uid://c6x21v7ya3eaw" path="res://blue_circle.tscn" id="2_6anmn"]
 [ext_resource type="PackedScene" uid="uid://dxq0fahcphpmb" path="res://pink_circle.tscn" id="3_elptk"]
 
 [node name="Main" type="Node2D"]
+script = ExtResource("1_g77aw")
 
 [node name="RedCircle" parent="." instance=ExtResource("1_ncan8")]
 position = Vector2(475, 206)

--- a/030_hover_effect_on_circles/pink_circle.tscn
+++ b/030_hover_effect_on_circles/pink_circle.tscn
@@ -10,7 +10,7 @@ script = ExtResource("1_drxbe")
 position = Vector2(3, 6)
 texture = ExtResource("1_4omff")
 
-[node name="Area2D" type="Area2D" parent="."]
+[node name="PinkArea2D" type="Area2D" parent="."]
 
-[node name="CollisionPolygon2D" type="CollisionPolygon2D" parent="Area2D"]
+[node name="CollisionPolygon2D" type="CollisionPolygon2D" parent="PinkArea2D"]
 polygon = PackedVector2Array(-6, -12, 8, -16, 20, -14, 26, -8, 26, -2, 12, 8, 2, 13, -10, 18, -18, 15, -21, 7, -21, -1, -15, -6)

--- a/030_hover_effect_on_circles/red_circle.tscn
+++ b/030_hover_effect_on_circles/red_circle.tscn
@@ -13,9 +13,9 @@ script = ExtResource("1_ca17s")
 [node name="Sprite2D" type="Sprite2D" parent="."]
 texture = ExtResource("1_dloi8")
 
-[node name="Area2D" type="Area2D" parent="."]
+[node name="RedArea2D" type="Area2D" parent="."]
 
-[node name="CollisionShape2D" type="CollisionShape2D" parent="Area2D"]
+[node name="CollisionShape2D" type="CollisionShape2D" parent="RedArea2D"]
 position = Vector2(0, -2)
 rotation = 1.13475
 shape = SubResource("CapsuleShape2D_0sdbu")


### PR DESCRIPTION
Added a script to main, inside _input() when the mouse is moved, I use intersect_point() to get an Array[Dictionary] that contains all overlapping areas.

It seems like the order is randomized though, so I run a sort on the resulting array to sort based on the tree order so that the result is always consistent.

Finally there is a setter property that stores the currently hovered circle, which then asks the old circle to shrink and the new circle to grow.
- The setter has some checks to run logic based on what the previous value was and what the new value is